### PR TITLE
WeChat login integration

### DIFF
--- a/Authgear.podspec
+++ b/Authgear.podspec
@@ -9,4 +9,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '11.0'
   s.swift_version = ['5.0', '5.1', '5.2']
   s.source_files = 'Source/**/*.swift'
+
+  # Dependencies
+  s.dependency 'Starscream', '~> 4.0.4'
 end

--- a/Authgear.xcodeproj/project.pbxproj
+++ b/Authgear.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		CC337EC0259063E500CBB3BB /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = CC337EBF259063E500CBB3BB /* Starscream */; };
+		CC337EC82590648800CBB3BB /* WSClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC337EC72590648800CBB3BB /* WSClient.swift */; };
 		F83392EF24FC344D00A69D3C /* Storage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F83392EE24FC344D00A69D3C /* Storage.swift */; };
 		F83392F124FDA87900A69D3C /* AuthgearError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F83392F024FDA87900A69D3C /* AuthgearError.swift */; };
 		F83392F324FE38FE00A69D3C /* URLComponents+QueryParames.swift in Sources */ = {isa = PBXBuildFile; fileRef = F83392F224FE38FE00A69D3C /* URLComponents+QueryParames.swift */; };
@@ -38,6 +39,7 @@
 /* Begin PBXFileReference section */
 		"Authgear::Authgear::Product" /* Authgear.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Authgear.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"Authgear::AuthgearTests::Product" /* Authgear-iOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = "Authgear-iOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		CC337EC72590648800CBB3BB /* WSClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WSClient.swift; sourceTree = "<group>"; };
 		F83392EE24FC344D00A69D3C /* Storage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Storage.swift; sourceTree = "<group>"; };
 		F83392F024FDA87900A69D3C /* AuthgearError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthgearError.swift; sourceTree = "<group>"; };
 		F83392F224FE38FE00A69D3C /* URLComponents+QueryParames.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLComponents+QueryParames.swift"; sourceTree = "<group>"; };
@@ -121,6 +123,7 @@
 				F8A657A42501D31E0027888F /* JWK.swift */,
 				F8A657A6250551ED0027888F /* JWT.swift */,
 				F8A657A825055A7C0027888F /* Data+Base64URLEncoded.swift */,
+				CC337EC72590648800CBB3BB /* WSClient.swift */,
 			);
 			path = Sources;
 			sourceTree = SOURCE_ROOT;
@@ -216,6 +219,7 @@
 				F8A657A7250551ED0027888F /* JWT.swift in Sources */,
 				F8A657A52501D31E0027888F /* JWK.swift in Sources */,
 				F8A657A32501845D0027888F /* Decodable+Any.swift in Sources */,
+				CC337EC82590648800CBB3BB /* WSClient.swift in Sources */,
 				F83D84AC24F66D3400B4393C /* APIClient.swift in Sources */,
 				F83D84B024F860AA00B4393C /* AuthenticationSession.swift in Sources */,
 				F83D84A824F64D0E00B4393C /* Authgear.swift in Sources */,

--- a/Authgear.xcodeproj/project.pbxproj
+++ b/Authgear.xcodeproj/project.pbxproj
@@ -3,10 +3,11 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		CC337EC0259063E500CBB3BB /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = CC337EBF259063E500CBB3BB /* Starscream */; };
 		F83392EF24FC344D00A69D3C /* Storage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F83392EE24FC344D00A69D3C /* Storage.swift */; };
 		F83392F124FDA87900A69D3C /* AuthgearError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F83392F024FDA87900A69D3C /* AuthgearError.swift */; };
 		F83392F324FE38FE00A69D3C /* URLComponents+QueryParames.swift in Sources */ = {isa = PBXBuildFile; fileRef = F83392F224FE38FE00A69D3C /* URLComponents+QueryParames.swift */; };
@@ -40,7 +41,7 @@
 		F83392EE24FC344D00A69D3C /* Storage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Storage.swift; sourceTree = "<group>"; };
 		F83392F024FDA87900A69D3C /* AuthgearError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthgearError.swift; sourceTree = "<group>"; };
 		F83392F224FE38FE00A69D3C /* URLComponents+QueryParames.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLComponents+QueryParames.swift"; sourceTree = "<group>"; };
-		F83D84A724F64D0E00B4393C /* Authgear.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Authgear.swift; path = Authgear.swift; sourceTree = "<group>"; };
+		F83D84A724F64D0E00B4393C /* Authgear.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Authgear.swift; sourceTree = "<group>"; };
 		F83D84A924F66C5100B4393C /* OIDCConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OIDCConfiguration.swift; sourceTree = "<group>"; };
 		F83D84AB24F66D3400B4393C /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		F83D84AD24F6A93600B4393C /* CodeVerifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeVerifier.swift; sourceTree = "<group>"; };
@@ -60,6 +61,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
+				CC337EC0259063E500CBB3BB /* Starscream in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -146,6 +148,9 @@
 			dependencies = (
 			);
 			name = "Authgear-iOS";
+			packageProductDependencies = (
+				CC337EBF259063E500CBB3BB /* Starscream */,
+			);
 			productName = Authgear;
 			productReference = "Authgear::Authgear::Product" /* Authgear.framework */;
 			productType = "com.apple.product-type.framework";
@@ -184,6 +189,9 @@
 				en,
 			);
 			mainGroup = OBJ_5;
+			packageReferences = (
+				CC337EBE259063E500CBB3BB /* XCRemoteSwiftPackageReference "Starscream" */,
+			);
 			productRefGroup = OBJ_13 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -245,7 +253,10 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Authgear.xcodeproj/Authgear_Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
@@ -275,7 +286,10 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Authgear.xcodeproj/Authgear_Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
@@ -334,7 +348,11 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Authgear.xcodeproj/AuthgearTests_Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@loader_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
@@ -360,7 +378,11 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Authgear.xcodeproj/AuthgearTests_Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@loader_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
@@ -394,7 +416,8 @@
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SWIFT_PACKAGE";
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				USE_HEADERMAP = NO;
 			};
 			name = Release;
@@ -430,6 +453,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		CC337EBE259063E500CBB3BB /* XCRemoteSwiftPackageReference "Starscream" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/daltoniam/Starscream.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 4.0.4;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		CC337EBF259063E500CBB3BB /* Starscream */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CC337EBE259063E500CBB3BB /* XCRemoteSwiftPackageReference "Starscream" */;
+			productName = Starscream;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = OBJ_1 /* Project object */;
 }

--- a/Authgear.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Authgear.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Starscream",
+        "repositoryURL": "https://github.com/daltoniam/Starscream.git",
+        "state": {
+          "branch": null,
+          "revision": "df8d82047f6654d8e4b655d1b1525c64e1059d21",
+          "version": "4.0.4"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Starscream",
+        "repositoryURL": "https://github.com/daltoniam/Starscream.git",
+        "state": {
+          "branch": null,
+          "revision": "df8d82047f6654d8e4b655d1b1525c64e1059d21",
+          "version": "4.0.4"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -11,11 +11,12 @@ let package = Package(
     )],
     dependencies: [ // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
+        .package(url: "https://github.com/daltoniam/Starscream.git", from: "4.0.4")
     ],
     targets: [
         .target(
             name: "Authgear",
-            dependencies: [],
+            dependencies: ["Starscream"],
             path: "Sources"
         ),
         .testTarget(

--- a/Sources/APIClient.swift
+++ b/Sources/APIClient.swift
@@ -495,7 +495,8 @@ class DefaultAuthAPIClient: AuthAPIClient {
         let u = endpoint.appendingPathComponent("/sso/wechat/callback")
         let queryItems = [
             URLQueryItem(name: "code", value: code),
-            URLQueryItem(name: "state", value: state)
+            URLQueryItem(name: "state", value: state),
+            URLQueryItem(name: "x_sdk", value: "ios")
         ]
         var urlComponents = URLComponents(
             url: u,
@@ -503,8 +504,11 @@ class DefaultAuthAPIClient: AuthAPIClient {
         )!
         urlComponents.queryItems = queryItems
         var urlRequest = URLRequest(url: urlComponents.url!)
-        urlRequest.httpMethod = "GET"
-        urlRequest.setValue("application/json", forHTTPHeaderField: "content-type")
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue(
+            "application/x-www-form-urlencoded",
+            forHTTPHeaderField: "content-type"
+        )
         fetch(request: urlRequest, handler: { result in
             handler(result.map { _ in () })
         })

--- a/Sources/APIClient.swift
+++ b/Sources/APIClient.swift
@@ -493,22 +493,23 @@ class DefaultAuthAPIClient: AuthAPIClient {
 
     func requestWeChatAuthCallback(code: String, state: String, handler: @escaping (Result<Void, Error>) -> Void) {
         let u = endpoint.appendingPathComponent("/sso/wechat/callback")
+
         let queryItems = [
             URLQueryItem(name: "code", value: code),
             URLQueryItem(name: "state", value: state),
             URLQueryItem(name: "x_sdk", value: "ios")
         ]
-        var urlComponents = URLComponents(
-            url: u,
-            resolvingAgainstBaseURL: false
-        )!
+        var urlComponents = URLComponents()
         urlComponents.queryItems = queryItems
-        var urlRequest = URLRequest(url: urlComponents.url!)
+
+        var urlRequest = URLRequest(url: u)
         urlRequest.httpMethod = "POST"
         urlRequest.setValue(
             "application/x-www-form-urlencoded",
             forHTTPHeaderField: "content-type"
         )
+        urlRequest.httpBody = urlComponents.query?.data(using: .utf8)
+
         fetch(request: urlRequest, handler: { result in
             handler(result.map { _ in () })
         })

--- a/Sources/Authgear.swift
+++ b/Sources/Authgear.swift
@@ -679,6 +679,21 @@ public class Authgear: NSObject {
             fetchUserInfo(accessToken ?? "")
         }
     }
+
+    public func weChatAuthCallback(code: String, state: String, handler: VoidCompletionHandler? = nil) {
+        let handler = handler.map { h in withMainQueueHandler(h) }
+        workerQueue.async {
+            do {
+                try self.apiClient.syncRequestWeChatAuthCallback(
+                    code: code,
+                    state: state
+                )
+                handler?(.success(()))
+            } catch {
+                handler?(.failure(error))
+            }
+        }
+    }
 }
 
 extension Authgear: AuthAPIClientDelegate {

--- a/Sources/Authgear.swift
+++ b/Sources/Authgear.swift
@@ -87,6 +87,7 @@ public enum SessionStateChangeReason: String {
 
 public protocol AuthgearDelegate: AnyObject {
     func authgearSessionStateDidChange(_ container: Authgear, reason: SessionStateChangeReason)
+    func sendWeChatAuthRequest(_ state: String)
 }
 
 public class Authgear: NSObject {
@@ -684,4 +685,19 @@ extension Authgear: AuthAPIClientDelegate {
     func getAccessToken() -> String? {
         accessToken
     }
+}
+
+extension Authgear: WSClientDelegate {
+    func onWebsocketEvent(_ event: WSEvent) {
+        switch event.kind {
+        case .weChatLoginStart:
+            if let state: String = event.data?["state"] as? String {
+                delegate?.sendWeChatAuthRequest(state)
+            }
+        case .webSessionRefresh:
+            break
+        }
+    }
+
+    func onWebsocketError(_ error: Error?) {}
 }

--- a/Sources/Authgear.swift
+++ b/Sources/Authgear.swift
@@ -195,6 +195,7 @@ public class Authgear: NSObject {
         queryItems.append(URLQueryItem(name: "client_id", value: clientId))
         queryItems.append(URLQueryItem(name: "redirect_uri", value: options.redirectURI))
         queryItems.append(URLQueryItem(name: "x_ws_channel_id", value: wsChannelID))
+        queryItems.append(URLQueryItem(name: "x_sdk", value: "ios"))
 
         if let state = options.state {
             queryItems.append(URLQueryItem(name: "state", value: state))

--- a/Sources/WSClient.swift
+++ b/Sources/WSClient.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Starscream
+
+struct WSEvent: Decodable {
+    let kind: WSMessageKind
+    let data: [String: Any]?
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case data
+    }
+
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        kind = try values.decode(WSMessageKind.self, forKey: .kind)
+        data = try values.decode([String: Any].self, forKey: .data)
+    }
+}
+
+public enum WSMessageKind: String, Decodable {
+    case webSessionRefresh = "refresh"
+    case weChatLoginStart = "wechat_login_start"
+}
+
+protocol WSClientDelegate: AnyObject {
+    func onWebsocketEvent(_ event: WSEvent) -> Void
+    func onWebsocketError(_ error: Error?) -> Void
+}
+
+protocol WSClient: AnyObject {
+    var endpoint: URL { get }
+    var delegate: WSClientDelegate? { get set }
+    func connect(_ channelID: String) -> Void
+    func disconnect() -> Void
+}
+
+class DefaultWSClient: WSClient, WebSocketDelegate {
+    public let endpoint: URL
+    private var socket: WebSocket?
+    private var isConnected: Bool = false
+
+    weak var delegate: WSClientDelegate?
+
+    init(endpoint: URL) {
+        let supportedSSLSchemes = ["wss", "https"]
+        let scheme = endpoint.scheme ?? "wss"
+        var port = endpoint.port
+        if port == nil {
+            if supportedSSLSchemes.contains(scheme) {
+                port = 443
+            } else {
+                port = 80
+            }
+        }
+        let url = "\(scheme)://\(endpoint.host!):\(port!)/ws"
+        self.endpoint = URL(string: url)!
+    }
+
+    func connect(_ channelID: String) {
+        // new websocket client will be created when calling connect
+        // try disconnect the existing client if it exists
+        disconnect()
+
+        let queryItems = [URLQueryItem(name: "x_ws_channel_id", value: channelID)]
+        var urlComponents = URLComponents(
+            url: endpoint,
+            resolvingAgainstBaseURL: false
+        )!
+        urlComponents.queryItems = queryItems
+
+        var request = URLRequest(url: urlComponents.url!)
+        request.timeoutInterval = 5
+        socket = WebSocket(request: request)
+        socket?.delegate = self
+        socket?.connect()
+    }
+
+    func disconnect() {
+        socket?.disconnect()
+        socket = nil
+    }
+
+    func didReceive(event: WebSocketEvent, client: WebSocket) {
+        switch event {
+        case .connected:
+            isConnected = true
+        case .disconnected(let _, let code):
+            if code != 1000 {
+                client.connect()
+            }
+            isConnected = false
+        case let .text(string):
+            let decorder = JSONDecoder()
+            decorder.keyDecodingStrategy = .convertFromSnakeCase
+            if let message = try? decorder.decode(WSEvent.self, from: string.data(using: .utf8)!) {
+                delegate?.onWebsocketEvent(message)
+            }
+        case .binary:
+            break
+        case .ping:
+            break
+        case .pong:
+            break
+        case .viabilityChanged:
+            break
+        case .reconnectSuggested:
+            break
+        case .cancelled:
+            isConnected = false
+        case let .error(error):
+            isConnected = false
+            delegate?.onWebsocketError(error)
+        }
+    }
+}


### PR DESCRIPTION
refs #40

~~The PR is still WIP, the websocket connection issue is not fixed yet. Seems related to Starscream, there are several connection related issues in the latest version of Starscream... e.g. https://github.com/daltoniam/Starscream/issues/850 . Still investigating.~~ I thought the ping/pog and reconnection should be handled by `Starscream` automatically, found that we need to handle in ourselves. Added commit to handle reconnection.

For the SDK part, the login flow will be as follow:
- we added delegate function `func sendWeChatAuthRequest(_ state: String)` for developer to implement to open WeChat SDK, when user click wechat login in authui, delegate function will be triggered
- after getting code from sdk, developer should call `weChatAuthCallback(code: String, state: String, handler: VoidCompletionHandler? = nil)` to complete the flow

The WeChat login integration is not added to the example, as the setup require universal link setup which doesn't work with enterprise apple developer account. 
To test and see the setup, please reference to the code here: https://github.com/carmenlau/authgear-sdk-ios/tree/773-wechat-example. I can add your app id to my apple-app-site-association if needed
