### PR TITLE
WeChat login with universal link

### DIFF
--- a/Sources/APIClient.swift
+++ b/Sources/APIClient.swift
@@ -130,6 +130,11 @@ protocol AuthAPIClient: AnyObject {
         refreshToken: String,
         handler: @escaping (Result<AppSessionTokenResponse, Error>) -> Void
     )
+    func requestWeChatAuthCallback(
+        code: String,
+        state: String,
+        handler: @escaping (Result<Void, Error>) -> Void
+    )
 }
 
 extension AuthAPIClient {
@@ -216,6 +221,15 @@ extension AuthAPIClient {
         try withSemaphore { handler in
             self.requestAppSessionToken(
                 refreshToken: refreshToken,
+                handler: handler
+            )
+        }
+    }
+
+    func syncRequestWeChatAuthCallback(code: String, state: String) throws {
+        try withSemaphore { handler in
+            self.requestWeChatAuthCallback(
+                code: code, state: state,
                 handler: handler
             )
         }
@@ -474,6 +488,28 @@ class DefaultAuthAPIClient: AuthAPIClient {
 
         fetch(request: urlRequest, handler: { (result: Result<APIResponse<AppSessionTokenResponse>, Error>) in
             handler(result.flatMap { $0.toResult() })
+        })
+    }
+
+    func requestWeChatAuthCallback(code: String, state: String, handler: @escaping (Result<Void, Error>) -> Void) {
+        let queryItems = [
+            URLQueryItem(name: "code", value: code),
+            URLQueryItem(name: "state", value: state),
+            URLQueryItem(name: "x_platform", value: "ios")
+        ]
+        var urlComponents = URLComponents()
+        urlComponents.queryItems = queryItems
+
+        let u = endpoint.appendingPathComponent("/sso/wechat/callback")
+        var urlRequest = URLRequest(url: u)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue(
+            "application/x-www-form-urlencoded",
+            forHTTPHeaderField: "content-type"
+        )
+        urlRequest.httpBody = urlComponents.query?.data(using: .utf8)
+        fetch(request: urlRequest, handler: { result in
+            handler(result.map { _ in () })
         })
     }
 }

--- a/Sources/Authgear.swift
+++ b/Sources/Authgear.swift
@@ -727,6 +727,21 @@ public class Authgear: NSObject {
             fetchUserInfo(accessToken ?? "")
         }
     }
+
+    public func weChatAuthCallback(code: String, state: String, handler: VoidCompletionHandler? = nil) {
+        let handler = handler.map { h in withMainQueueHandler(h) }
+        workerQueue.async {
+            do {
+                try self.apiClient.syncRequestWeChatAuthCallback(
+                    code: code,
+                    state: state
+                )
+                handler?(.success(()))
+            } catch {
+                handler?(.failure(error))
+            }
+        }
+    }
 }
 
 extension Authgear: AuthAPIClientDelegate {

--- a/Sources/Authgear.swift
+++ b/Sources/Authgear.swift
@@ -4,7 +4,6 @@ import SafariServices
 import WebKit
 
 public typealias AuthorizeCompletionHandler = (Result<AuthorizeResult, Error>) -> Void
-public typealias AuthorizeRedirectionHandler = (URL) -> Void
 public typealias UserInfoCompletionHandler = (Result<UserInfo, Error>) -> Void
 public typealias VoidCompletionHandler = (Result<Void, Error>) -> Void
 
@@ -133,7 +132,6 @@ public class Authgear: NSObject {
     private var currentWeChatRedirectURI: String?
 
     public private(set) var sessionState: SessionState = .unknown
-    public private(set) var authorizeRedirectionHandler: AuthorizeRedirectionHandler?
 
     public weak var delegate: AuthgearDelegate?
 
@@ -432,7 +430,6 @@ public class Authgear: NSObject {
     }
 
     public func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
-        authorizeRedirectionHandler?(url)
         _ = handleWeChatRedirectURI(url)
         return true
     }

--- a/Sources/Authgear.swift
+++ b/Sources/Authgear.swift
@@ -15,6 +15,7 @@ struct AuthorizeOptions {
     let prompt: String?
     let loginHint: String?
     let uiLocales: [String]?
+    let weChatRedirectURI: String?
 
     var urlScheme: String {
         if let index = redirectURI.firstIndex(of: ":") {
@@ -29,7 +30,8 @@ struct AuthorizeOptions {
         state: String?,
         prompt: String?,
         loginHint: String?,
-        uiLocales: [String]?
+        uiLocales: [String]?,
+        weChatRedirectURI: String?
     ) {
         self.redirectURI = redirectURI
         self.responseType = responseType
@@ -37,6 +39,7 @@ struct AuthorizeOptions {
         self.prompt = prompt
         self.loginHint = loginHint
         self.uiLocales = uiLocales
+        self.weChatRedirectURI = weChatRedirectURI
     }
 }
 
@@ -211,6 +214,13 @@ public class Authgear: NSObject {
             ))
         }
 
+        if let weChatRedirectURI = options.weChatRedirectURI {
+            queryItems.append(URLQueryItem(
+                name: "x_wechat_redirect_uri",
+                value: weChatRedirectURI
+            ))
+        }
+
         var urlComponents = URLComponents(
             url: configuration.authorizationEndpoint,
             resolvingAgainstBaseURL: false
@@ -381,6 +391,7 @@ public class Authgear: NSObject {
         prompt: String? = "login",
         loginHint: String? = nil,
         uiLocales: [String]? = nil,
+        weChatRedirectURI: String? = nil,
         handler: @escaping AuthorizeCompletionHandler
     ) {
         authorize(
@@ -390,7 +401,8 @@ public class Authgear: NSObject {
                 state: state,
                 prompt: prompt,
                 loginHint: loginHint,
-                uiLocales: uiLocales
+                uiLocales: uiLocales,
+                weChatRedirectURI: weChatRedirectURI
             ),
             handler: withMainQueueHandler(handler)
         )
@@ -449,6 +461,7 @@ public class Authgear: NSObject {
         redirectURI: String,
         state: String? = nil,
         uiLocales: [String]? = nil,
+        weChatRedirectURI: String? = nil,
         handler: @escaping AuthorizeCompletionHandler
     ) {
         let handler = withMainQueueHandler(handler)
@@ -486,7 +499,8 @@ public class Authgear: NSObject {
                         state: state,
                         prompt: "login",
                         loginHint: loginHint,
-                        uiLocales: uiLocales
+                        uiLocales: uiLocales,
+                        weChatRedirectURI: weChatRedirectURI
                     )
                 ) { [weak self] result in
                     guard let this = self else { return }
@@ -557,7 +571,8 @@ public class Authgear: NSObject {
                         state: nil,
                         prompt: "none",
                         loginHint: loginHint,
-                        uiLocales: nil
+                        uiLocales: nil,
+                        weChatRedirectURI: nil
                     ),
                     verifier: nil
                 )

--- a/Sources/Authgear.swift
+++ b/Sources/Authgear.swift
@@ -221,6 +221,8 @@ public class Authgear: NSObject {
             ))
         }
 
+        queryItems.append(URLQueryItem(name: "x_platform", value: "ios"))
+
         var urlComponents = URLComponents(
             url: configuration.authorizationEndpoint,
             resolvingAgainstBaseURL: false

--- a/Sources/Authgear.swift
+++ b/Sources/Authgear.swift
@@ -400,7 +400,7 @@ public class Authgear: NSObject {
         currentWeChatRedirectURI = nil
     }
 
-    public func handleWeChatRedirectURI(_ url: URL) -> Bool {
+    private func handleWeChatRedirectURI(_ url: URL) -> Bool {
         if currentWeChatRedirectURI == nil {
             return false
         }
@@ -433,7 +433,17 @@ public class Authgear: NSObject {
 
     public func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
         authorizeRedirectionHandler?(url)
+        _ = handleWeChatRedirectURI(url)
         return true
+    }
+
+    @available(iOS 13.0, *)
+    public func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+        guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+              let url = userActivity.webpageURL else {
+            return
+        }
+        _ = handleWeChatRedirectURI(url)
     }
 
     public func authorize(

--- a/Sources/Authgear.swift
+++ b/Sources/Authgear.swift
@@ -92,6 +92,10 @@ public protocol AuthgearDelegate: AnyObject {
     func authgearSessionStateDidChange(_ container: Authgear, reason: SessionStateChangeReason)
 }
 
+public extension AuthgearDelegate {
+    func authgearSessionStateDidChange(_ container: Authgear, reason: SessionStateChangeReason) {}
+}
+
 public class Authgear: NSObject {
     /**
      * To prevent user from using expired access token, we have to check in advance


### PR DESCRIPTION
refs #40 

Since the wechat implementation requires universal link setup, so adding wechat login in example is not included in this PR. The example PR will be done when we do the auto testflight build setup.

For the example of usage: https://github.com/carmenlau/authgear-sdk-ios/tree/40-wechat-login-example