### PR TITLE
Update app delegate function to handle wechat redirect uri correctly

### DIFF
--- a/Sources/Authgear.swift
+++ b/Sources/Authgear.swift
@@ -429,8 +429,15 @@ public class Authgear: NSObject {
         return false
     }
 
-    public func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
-        _ = handleWeChatRedirectURI(url)
+    public func application(
+        _ application: UIApplication,
+        continue userActivity: NSUserActivity,
+        restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void
+    ) -> Bool {
+        if userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+           let url = userActivity.webpageURL {
+            _ = handleWeChatRedirectURI(url)
+        }
         return true
     }
 

--- a/example/ios_example/AppDelegate.swift
+++ b/example/ios_example/AppDelegate.swift
@@ -20,13 +20,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
         UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
-
-    // Handle redirection after OAuth completed or failed
-    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
-        guard let c = appContainer.container else {
-            // not yet configured
-            return true
-        }
-        return c.application(app, open: url, options: options)
-    }
 }


### PR DESCRIPTION
refs #40 

The open url function is used to handle custom url scheme, which is not suitable
for handling wechat redirect uri which is universal link.
I don't need to call it in example app, as example app adopt scenes.