### PR TITLE
Update SDK reference for authenticate param

### DIFF
--- a/Sources/Authgear.swift
+++ b/Sources/Authgear.swift
@@ -818,10 +818,8 @@ public class Authgear {
     ///   - xState: Use this parameter to provide parameters from the client application to Custom UI. The string in xState can be accessed by the Custom UI. Ignore this parameter if default AuthUI is used
     public func authenticate(
         redirectURI: String,
-        state: String? = nil,
         xState: String? = nil,
         prompt: [PromptOption]? = nil,
-        loginHint: String? = nil,
         uiLocales: [String]? = nil,
         colorScheme: ColorScheme? = nil,
         wechatRedirectURI: String? = nil,
@@ -833,10 +831,10 @@ public class Authgear {
             redirectURI: redirectURI,
             isSSOEnabled: self.isSSOEnabled,
             preAuthenticatedURLEnabled: self.preAuthenticatedURLEnabled,
-            state: state,
+            state: nil,
             xState: xState,
             prompt: prompt,
-            loginHint: loginHint,
+            loginHint: nil,
             uiLocales: uiLocales,
             colorScheme: colorScheme,
             wechatRedirectURI: wechatRedirectURI,

--- a/Sources/Authgear.swift
+++ b/Sources/Authgear.swift
@@ -813,6 +813,9 @@ public class Authgear {
         _ = handleWechatRedirectURI(url)
     }
 
+    
+    /// - Parameters:
+    ///   - xState: Use this parameter to provide parameters from the client application to Custom UI. The string in xState can be accessed by the Custom UI. Ignore this parameter if default AuthUI is used
     public func authenticate(
         redirectURI: String,
         state: String? = nil,


### PR DESCRIPTION
@louischan-oursky see if this approach ok or not
i found there is already a `private authenticate` function for handling a complete `AuthenticateOption` param, and all places using `public authenticate` function didnt use the two params that need to be hidden. so if they are not exposing then should be ok to remove from the `public authenticate` function

Preview:

<img width="997" alt="Screenshot 2024-09-04 at 12 18 22 PM" src="https://github.com/user-attachments/assets/3fcf836a-898d-4ce0-8d72-8fa7203360c2">
