### PR TITLE
Fix ruby-jwt empty-key HMAC bypass

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,7 +237,7 @@ GEM
       xcinvoke (~> 0.3.0)
     jmespath (1.6.2)
     json (2.10.2)
-    jwt (2.10.1)
+    jwt (2.10.2)
       base64
     liferaft (0.0.6)
     logger (1.6.6)


### PR DESCRIPTION
Bump jwt from 2.10.1 to 2.10.2.