### PR TITLE
Clear session on invalid_dpop_proof during token refresh

### DIFF
--- a/Sources/Authgear.swift
+++ b/Sources/Authgear.swift
@@ -1435,7 +1435,7 @@ public class Authgear {
             } catch {
                 if let error = error as? AuthgearError,
                    case let .oauthError(oauthError) = error,
-                   oauthError.error == "invalid_grant" {
+                   oauthError.error == "invalid_grant" || oauthError.error == "invalid_dpop_proof" {
                     self._handleInvalidGrantException(error: error, handler: handler)
                     return
                 }
@@ -1931,7 +1931,7 @@ public class Authgear {
     private func _handleInvalidGrantException(error: Error, handler: VoidCompletionHandler? = nil) {
         if let error = error as? AuthgearError,
            case let .oauthError(oauthError) = error,
-           oauthError.error == "invalid_grant" {
+           oauthError.error == "invalid_grant" || oauthError.error == "invalid_dpop_proof" {
             return self.cleanupSession(force: true, reason: .invalid) { result in handler?(result) }
         } else if let error = error as? AuthgearError,
                   case let .serverError(serverError) = error,

--- a/Sources/Authgear.swift
+++ b/Sources/Authgear.swift
@@ -263,12 +263,15 @@ public enum SessionStateChangeReason: String {
 }
 
 public protocol AuthgearDelegate: AnyObject {
-    func authgearSessionStateDidChange(_ container: Authgear, reason: SessionStateChangeReason)
+    // error is non-nil when reason is .invalid, i.e. the session was cleared
+    // because a request failed with an error such as invalid_grant or
+    // invalid_dpop_proof. It is nil for all other reasons.
+    func authgearSessionStateDidChange(_ container: Authgear, reason: SessionStateChangeReason, error: Error?)
     func sendWechatAuthRequest(_ state: String)
 }
 
 public extension AuthgearDelegate {
-    func authgearSessionStateDidChange(_ container: Authgear, reason: SessionStateChangeReason) {}
+    func authgearSessionStateDidChange(_ container: Authgear, reason: SessionStateChangeReason, error: Error?) {}
     func sendWechatAuthRequest(_ state: String) {}
 }
 
@@ -421,9 +424,9 @@ public class Authgear {
         }
     }
 
-    private func setSessionState(_ newState: SessionState, reason: SessionStateChangeReason) {
+    private func setSessionState(_ newState: SessionState, reason: SessionStateChangeReason, error: Error? = nil) {
         sessionState = newState
-        delegate?.authgearSessionStateDidChange(self, reason: reason)
+        delegate?.authgearSessionStateDidChange(self, reason: reason, error: error)
     }
 
     func buildAuthorizationURL(request: OIDCAuthenticationRequest, clientID: String, verifier: CodeVerifier?) throws -> URL {
@@ -726,7 +729,7 @@ public class Authgear {
         }
     }
 
-    private func cleanupSession(force: Bool, reason: SessionStateChangeReason, handler: @escaping VoidCompletionHandler) {
+    private func cleanupSession(force: Bool, reason: SessionStateChangeReason, error: Error? = nil, handler: @escaping VoidCompletionHandler) {
         if case let .failure(error) = Result(catching: { try tokenStorage.delRefreshToken(namespace: name) }) {
             if !force {
                 return handler(.failure(wrapError(error: error)))
@@ -748,7 +751,7 @@ public class Authgear {
             self.refreshToken = nil
             self.idToken = nil
             self.expireAt = nil
-            self.setSessionState(.noSession, reason: reason)
+            self.setSessionState(.noSession, reason: reason, error: error)
             handler(.success(()))
         }
     }
@@ -1929,14 +1932,14 @@ public class Authgear {
     }
 
     private func _handleInvalidGrantException(error: Error, handler: VoidCompletionHandler? = nil) {
-        if let error = error as? AuthgearError,
-           case let .oauthError(oauthError) = error,
+        if let authgearError = error as? AuthgearError,
+           case let .oauthError(oauthError) = authgearError,
            oauthError.error == "invalid_grant" || oauthError.error == "invalid_dpop_proof" {
-            return self.cleanupSession(force: true, reason: .invalid) { result in handler?(result) }
-        } else if let error = error as? AuthgearError,
-                  case let .serverError(serverError) = error,
+            return self.cleanupSession(force: true, reason: .invalid, error: error) { result in handler?(result) }
+        } else if let authgearError = error as? AuthgearError,
+                  case let .serverError(serverError) = authgearError,
                   serverError.reason == "InvalidGrant" {
-            return self.cleanupSession(force: true, reason: .invalid) { result in handler?(result) }
+            return self.cleanupSession(force: true, reason: .invalid, error: error) { result in handler?(result) }
         }
         handler?(.success(()))
     }

--- a/example/ios_example/App.swift
+++ b/example/ios_example/App.swift
@@ -341,6 +341,22 @@ class App: ObservableObject {
         self.fetchUserInfo(container: container)
     }
 
+    /// Unlike fetchUserInfo(), this does NOT chain any follow-up request
+    /// after refresh, so the refresh result (e.g. invalid_grant vs
+    /// invalid_dpop_proof) is not masked by a subsequent request made with a
+    /// stale/missing access token.
+    func refreshAccessToken() {
+        guard let container = container else { return }
+        container.refreshAccessTokenIfNeeded { result in
+            switch result {
+            case .success:
+                self.successAlertMessage = "Refreshed access token successfully.\nsessionState: \(container.sessionState.rawValue)"
+            case let .failure(error):
+                self.setError(error)
+            }
+        }
+    }
+
     func showAuthTime() {
         let f = DateFormatter()
         f.dateStyle = .long

--- a/example/ios_example/AppDelegate.swift
+++ b/example/ios_example/AppDelegate.swift
@@ -105,6 +105,13 @@ extension AppDelegate: AuthgearDelegate {
 
     func authgearSessionStateDidChange(_ container: Authgear, reason: SessionStateChangeReason, error: Error?) {
         print(#line, "authgearSessionStateDidChange: sessionState=\(container.sessionState) reason=\(reason.rawValue) error=\(String(describing: error))")
+        if let error = error as? AuthgearError, case let .oauthError(oauthError) = error {
+            if oauthError.error == "invalid_grant" {
+                print(#line, "authgearSessionStateDidChange: error is invalid_grant")
+            } else if oauthError.error == "invalid_dpop_proof" {
+                print(#line, "authgearSessionStateDidChange: error is invalid_dpop_proof")
+            }
+        }
         appContainer.sessionState = container.sessionState
     }
 }

--- a/example/ios_example/AppDelegate.swift
+++ b/example/ios_example/AppDelegate.swift
@@ -103,7 +103,8 @@ extension AppDelegate: AuthgearDelegate {
         WXApi.send(req)
     }
 
-    func authgearSessionStateDidChange(_ container: Authgear, reason: SessionStateChangeReason) {
+    func authgearSessionStateDidChange(_ container: Authgear, reason: SessionStateChangeReason, error: Error?) {
+        print(#line, "authgearSessionStateDidChange: sessionState=\(container.sessionState) reason=\(reason.rawValue) error=\(String(describing: error))")
         appContainer.sessionState = container.sessionState
     }
 }

--- a/example/ios_example/ContentView.swift
+++ b/example/ios_example/ContentView.swift
@@ -327,6 +327,12 @@ struct ActionButtonList: View {
                 }.disabled(!configured || !loggedIn)
 
                 Button(action: {
+                    self.app.refreshAccessToken()
+                }) {
+                    ActionButton(text: "Refresh Access Token If Needed")
+                }.disabled(!configured || !loggedIn)
+
+                Button(action: {
                     self.app.openSetting()
                 }) {
                     ActionButton(text: "Open Setting")


### PR DESCRIPTION
ref DEV-3680

To test this:

1. Check out commit `c629740`, then log in.

2. Replace the DPoP jkt by updating the Redis data in server:

   ```sh
   GRANT_ID=<the_grant_id>
   KEY="app:accounts:offline-grant:$GRANT_ID"
   TTL=$(redis-cli TTL "$KEY")

   redis-cli --raw GET "$KEY" > blob.json
   jq '.refresh_tokens[0].dpop_jkt = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef00"' blob.json > blob2.json

   redis-cli -x SET "$KEY" < blob2.json
   [ "$TTL" -ge 0 ] && redis-cli EXPIRE "$KEY" "$TTL"
   ```
   
   _To make it easier to find the grant ID, I used a clean Redis instance in my setup._

3. Restart the app, then click **"Refresh access token"**. You should see the `invalid_dpop_proof` error, but the app remains logged in.

4. Repeat the same steps on commit `3d09644`. This time, the session should be cleared and the app should be logged out.

--- 

Another note:

- dpop is working on the ios simulator
- We talked about clock-drifted devices. If the device clock is drifted by more than 5 minutes, the server returns `ErrProofExpired`, which is also mapped to the `invalid_dpop_proof` error. As a result, the app will also be logged out in this case.

https://github.com/authgear/authgear-server/blob/54b381a0a58f2c61699390402cca3d1f1d4a9859/pkg/lib/dpop/provider.go#L76